### PR TITLE
build.sh: Add build.sh script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ ResetVector.*.raw
 /Conf
 /PayloadPkg/PayloadBins
 PayloadModPkg
+edk2
+SblKeys
+image.rom

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 # Install build dependencies
 RUN apt-get update && apt-get -y install sudo build-essential python3 python-is-python3 \
-    uuid-dev nasm openssl gcc-multilib git m4 bison flex qemu-system-x86
+    uuid-dev nasm openssl gcc-multilib git m4 bison flex qemu-system-x86 clang llvm lld
 
 # Install ACPICA Utilities
 RUN apt-get -y install acpica-tools
-RUN apt-get -y install python3-distutils
+RUN apt-get -y install python3-setuptools
 
 # Install stitching dependencies
 RUN apt-get install -y --no-install-recommends libxcb1 \
@@ -23,7 +23,7 @@ RUN apt-get install --no-install-recommends -y locales && \
     locale-gen ${LANG} && update-locale LANG=${LANG}
 
 # Add a user account, give sudo access
-RUN useradd -m docker && echo "docker:docker" | chpasswd && adduser docker sudo
+RUN deluser --remove-home ubuntu && useradd -U -u 1000 -m docker && echo "docker:docker" | chpasswd && adduser docker sudo
 
 USER docker
 RUN git config --global user.name "User" && git config --global user.email "user@example.com"

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+set -Eeuo pipefail
+
+trap 'echo "Build failed."' ERR
+
+usage() {
+  echo "${0} CMD"
+  echo "Available CMDs:"
+  echo -e "\todroid_h4              - build Dasharo compatible with Hardkernel ODROID H4"
+}
+
+INPUT_IMAGE="${INPUT_IMAGE:-image.rom}"
+
+build_odroid_h4() {
+  local flags="-D CRYPTO_PROTOCOL_SUPPORT=TRUE -D SIO_BUS_ENABLE=TRUE \
+    -D PERFORMANCE_MEASUREMENT_ENABLE=TRUE \
+    -D MULTIPLE_DEBUG_PORT_SUPPORT=TRUE -D BOOTSPLASH_IMAGE=TRUE \
+    -D BOOT_MANAGER_ESCAPE=TRUE"
+  if [ ! -f "$INPUT_IMAGE" ]; then
+    echo "$INPUT_IMAGE doesn't exist or isn't file."
+    echo "You can set different path to vendor image in INPUT_IMAGE variable"
+    exit 1
+  fi
+  docker build -t sbl --network=host .
+  build_edk2 "edk2-stable202505" "$flags"
+  build_slimloader odroidh4 "0xAAFFFF0C"
+  echo "Result binary placed in $PWD/Outputs/odroidh4/ifwi-release.bin"
+  sha256sum Outputs/odroidh4/ifwi-release.bin >Outputs/odroidh4/ifwi-release.bin.sha256
+}
+
+build_edk2() {
+  EDK2_VERSION="$1"
+  FLAGS="$2"
+  rm -rf edk2
+  mkdir edk2
+  cd edk2
+  # clone one commit only
+  git init
+  git remote remove origin 2>/dev/null || true
+  git remote add origin https://github.com/tianocore/edk2.git
+  git fetch --depth 1 origin "$EDK2_VERSION"
+  git checkout FETCH_HEAD --force
+  git submodule update --init --checkout --recursive --depth 1
+
+  docker run --rm -i -u "$UID" -v "$PWD":/edk2 -w /edk2 sbl /bin/bash <<EOF
+source edksetup.sh
+make -C BaseTools
+python ./UefiPayloadPkg/UniversalPayloadBuild.py -t GCC5 -o Dasharo -b RELEASE \
+  $FLAGS
+EOF
+  cd ..
+}
+
+build_slimloader() {
+  platform="$1"
+  platform_data="$2"
+  input="$(realpath "$INPUT_IMAGE")"
+  git submodule update --init --checkout --recursive --depth 1
+  mkdir -p PayloadPkg/PayloadBins/
+  cp edk2/Build/UefiPayloadPkgX64/UniversalPayload.elf PayloadPkg/PayloadBins/
+  docker run --rm -i -u $UID -v "$input":/tmp/image.rom -v "$PWD":/home/docker/slimbootloader \
+    -w /home/docker/slimbootloader sbl /bin/bash <<EOF
+export SBL_KEY_DIR="\${PWD}/SblKeys"
+if [ ! -d "\$SBL_KEY_DIR" ]; then
+  python BootloaderCorePkg/Tools/GenerateKeys.py -k "\$SBL_KEY_DIR"
+fi
+python BuildLoader.py build "$platform" -r \
+  -p "OsLoader.efi:LLDR:Lz4;UniversalPayload.elf:UEFI:Lzma"
+python Platform/AlderlakeBoardPkg/Script/StitchLoader.py \
+  -i "/tmp/image.rom" \
+  -s "Outputs/$platform/SlimBootloader.bin" \
+  -o "Outputs/$platform/ifwi-release.bin" \
+  -p "$platform_data"
+EOF
+}
+
+if [ $# -ne 1 ]; then
+  usage
+  echo ""
+  echo "Error: missing CMD"
+  exit 1
+fi
+
+CMD="$1"
+
+case "$CMD" in
+    "odroid_h4" | "odroid_H4" | "ODROID_H4" )
+        build_odroid_h4 ""
+        ;;
+    *)
+        echo "Invalid command: \"$CMD\""
+        usage
+        ;;
+esac


### PR DESCRIPTION
Hmm, building from scratch (from cloning slimbootloader step) failed, I have to check it out:

```
fatal: could not create leading directories of '/Download/AlderlakePkg/IntelFsp': Permission denied
(...)
FileNotFoundError: [Errno 2] No such file or directory: 'Outputs/odroidh4/SlimBootloader.bin
```

Edit: fixed, problem was that `python BuildLoader.py build` downloads some files to `../Downloads` (which resolved to `/Downloads` as slimbootloader was mounted at `/`)